### PR TITLE
Dutch/belgian typo in 'about' page

### DIFF
--- a/app/src/main/res/values-nl-rBE/strings.xml
+++ b/app/src/main/res/values-nl-rBE/strings.xml
@@ -131,7 +131,7 @@
 	<string name="settings_category_other">Overig:</string>
 	<string name="settings_device">Apparaat</string>
 	<string name="settings_entered_incorrectly">Fout tijdens opslaan van je instellingen. Ga terug en stel je instellingen opnieuw in.</string>
-	<string name="settings_explanation_incremental_full_update">"Een incrementele update kan worden geïnstalleerd vanaf elke versie (behalve als je een ontgrendelde bootloader hebt; dan moet je altijd voor de update-methode \'volledige update\' kiezen).\n\nEen bèta-versie kan ten alle tijden geïnstalleerd worden. Ook als je een stabiele versie draait. Om te wisselen van de stabiele versies naar bèta's, moet je \'geavanceerde modus\' aanzetten in de instellingen. Bij bèta's werken incrementele en volledige updates op dezelfde manier als bij de stabiele versie."</string>
+	<string name="settings_explanation_incremental_full_update">"Een incrementele update kan worden geïnstalleerd vanaf elke versie (behalve als je een ontgrendelde bootloader hebt; dan moet je altijd voor de update-methode \'volledige update\' kiezen).\n\nEen bèta-versie kan te allen tijde geïnstalleerd worden. Ook als je een stabiele versie draait. Om te wisselen van de stabiele versies naar bèta's, moet je \'geavanceerde modus\' aanzetten in de instellingen. Bij bèta's werken incrementele en volledige updates op dezelfde manier als bij de stabiele versie."</string>
 	<string name="settings_explanation_update_methods">Toelichting op de update-methodes</string>
 	<string name="settings_header">Kies je apparaat en update-methode</string>
 

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -131,7 +131,7 @@
 	<string name="settings_category_other">Overig:</string>
 	<string name="settings_device">Apparaat</string>
 	<string name="settings_entered_incorrectly">Fout tijdens opslaan van je instellingen. Ga terug en stel je instellingen opnieuw in.</string>
-	<string name="settings_explanation_incremental_full_update">"Een incrementele update kan worden geïnstalleerd vanaf elke versie (behalve als je een ontgrendelde bootloader hebt; dan moet je altijd voor de update-methode \'volledige update\' kiezen).\n\nEen bèta-versie kan ten alle tijden geïnstalleerd worden. Ook als je een stabiele versie draait. Om te wisselen van de stabiele versies naar bèta's, moet je \'geavanceerde modus\' aanzetten in de instellingen. Bij bèta's werken incrementele en volledige updates op dezelfde manier als bij de stabiele versie."</string>
+	<string name="settings_explanation_incremental_full_update">"Een incrementele update kan worden geïnstalleerd vanaf elke versie (behalve als je een ontgrendelde bootloader hebt; dan moet je altijd voor de update-methode \'volledige update\' kiezen).\n\nEen bèta-versie kan te allen tijde geïnstalleerd worden. Ook als je een stabiele versie draait. Om te wisselen van de stabiele versies naar bèta's, moet je \'geavanceerde modus\' aanzetten in de instellingen. Bij bèta's werken incrementele en volledige updates op dezelfde manier als bij de stabiele versie."</string>
 	<string name="settings_explanation_update_methods">Toelichting op de update-methodes</string>
 	<string name="settings_header">Kies je apparaat en update-methode</string>
 


### PR DESCRIPTION
## What's changed?
*Fixed Dutch/Belgian typos in 'about' page*
